### PR TITLE
Introducing method to run unchecked commands

### DIFF
--- a/src/gitbolt/git_subprocess/__init__.py
+++ b/src/gitbolt/git_subprocess/__init__.py
@@ -11,4 +11,5 @@ from gitbolt.git_subprocess.base import GitSubcmdCommand as GitSubcmdCommand
 from gitbolt.git_subprocess.base import AddCommand as AddCommand
 from gitbolt.git_subprocess.base import LsTreeCommand as LsTreeCommand
 from gitbolt.git_subprocess.base import VersionCommand as VersionCommand
+from gitbolt.git_subprocess.base import UncheckedSubcmd as UncheckedSubcmd
 # endregion

--- a/src/gitbolt/git_subprocess/base.py
+++ b/src/gitbolt/git_subprocess/base.py
@@ -13,6 +13,7 @@ from subprocess import CompletedProcess
 from typing import override, Protocol, Unpack, Self, overload, Literal, Any
 
 from vt.utils.commons.commons.core_py import is_unset, not_none_not_unset
+from vt.utils.commons.commons.op import RootDirOp
 
 from gitbolt import Git, Version, LsTree, GitSubCommand, HasGitUnderneath, Add
 from gitbolt.git_subprocess.add import AddCLIArgsBuilder, IndividuallyOverridableACAB
@@ -445,7 +446,7 @@ class AddCommand(Add, GitSubcmdCommand, Protocol):
         return IndividuallyOverridableACAB()
 
 
-class UncheckedSubcmd(GitSubcmdCommand, Protocol):
+class UncheckedSubcmd(GitSubcmdCommand, RootDirOp, Protocol):
     """
     Unchecked git subcommand. Runs subcommands directly in subprocess.
     """

--- a/src/gitbolt/git_subprocess/base.py
+++ b/src/gitbolt/git_subprocess/base.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from abc import abstractmethod, ABC
 from pathlib import Path
-from typing import override, Protocol, Unpack, Self, overload, Literal
+from subprocess import CompletedProcess
+from typing import override, Protocol, Unpack, Self, overload, Literal, Any
 
 from vt.utils.commons.commons.core_py import is_unset, not_none_not_unset
 
@@ -283,6 +284,14 @@ class GitCommand(Git, ABC):
     @abstractmethod
     def add_subcmd(self) -> AddCommand: ...
 
+    @property
+    @abstractmethod
+    def subcmd_unchecked(self) -> UncheckedSubcmd:
+        """
+        Run an unchecked git subcommand using subprocess.
+        """
+        ...
+
 
 class GitSubcmdCommand(GitSubCommand, HasGitUnderneath["GitCommand"], Protocol):
     """
@@ -434,3 +443,83 @@ class AddCommand(Add, GitSubcmdCommand, Protocol):
         :return: Builder the complete list of subcommand CLI arguments to be passed to ``git add`` subprocess.
         """
         return IndividuallyOverridableACAB()
+
+
+class UncheckedSubcmd(GitSubcmdCommand, Protocol):
+    """
+    Unchecked git subcommand. Runs subcommands directly in subprocess.
+    """
+
+    @overload
+    def run(
+        self,
+        subcommand_args: list[str],
+        *subprocess_run_args: Any,
+        _input: str,
+        text: Literal[True],
+        **subprocess_run_kwargs: Any,
+    ) -> CompletedProcess[str]: ...
+
+    @overload
+    def run(
+        self,
+        subcommand_args: list[str],
+        *subprocess_run_args: Any,
+        _input: bytes,
+        text: Literal[False],
+        **subprocess_run_kwargs: Any,
+    ) -> CompletedProcess[bytes]: ...
+
+    @overload
+    def run(
+        self,
+        subcommand_args: list[str],
+        *subprocess_run_args: Any,
+        text: Literal[True],
+        **subprocess_run_kwargs: Any,
+    ) -> CompletedProcess[str]: ...
+
+    @overload
+    def run(
+        self,
+        subcommand_args: list[str],
+        *subprocess_run_args: Any,
+        text: Literal[False] = ...,
+        **subprocess_run_kwargs: Any,
+    ) -> CompletedProcess[bytes]: ...
+
+    def run(
+        self,
+        subcommand_args: list[str],
+        *subprocess_run_args: Any,
+        _input: str | bytes | None = None,
+        text: Literal[True, False] = False,
+        **subprocess_run_kwargs,
+    ) -> CompletedProcess[str] | CompletedProcess[bytes]:
+        """
+        Run unchecked git subcommand using subprocess
+
+        :param subcommand_args: the full subcommand argument list.
+        :param subprocess_run_args: additional subprocess positionals.
+        :param _input: any stdin to be passed to the subprocess.
+        :param text: ``_input`` and returns both are str if this value is ``True``. Else, bytes are considered.
+        :param subprocess_run_kwargs: additional subprocess keyword arguments.
+
+        :return: ``CompletedProcess`` capturing all the required stdout, stderr, return-code etc.
+        """
+        main_cmd_args = self.underlying_git.build_main_cmd_args()
+        envs_vars = self.underlying_git.build_git_envs()
+        another_supplied_env = subprocess_run_kwargs.pop('env', None)
+        if another_supplied_env:
+            envs_vars.update(another_supplied_env)
+        # Run the git command
+        result = self.underlying_git.runner.run_git_command(
+            main_cmd_args,
+            subcommand_args,
+            *subprocess_run_args,
+            _input=_input,
+            text=text,
+            env=envs_vars,
+            **subprocess_run_kwargs
+        )
+        return result

--- a/src/gitbolt/git_subprocess/base.py
+++ b/src/gitbolt/git_subprocess/base.py
@@ -450,6 +450,10 @@ class UncheckedSubcmd(GitSubcmdCommand, Protocol):
     Unchecked git subcommand. Runs subcommands directly in subprocess.
     """
 
+    @override
+    def _subcmd_from_git(self, git: "Git") -> Self:
+        return self
+
     @overload
     def run(
         self,

--- a/src/gitbolt/git_subprocess/base.py
+++ b/src/gitbolt/git_subprocess/base.py
@@ -517,6 +517,9 @@ class UncheckedSubcmd(GitSubcmdCommand, RootDirOp, Protocol):
         another_supplied_env = subprocess_run_kwargs.pop('env', None)
         if another_supplied_env:
             envs_vars.update(another_supplied_env)
+        cwd = subprocess_run_kwargs.pop('cwd', None) or self.root_dir
+        capture_output = subprocess_run_kwargs.pop('capture_output', None) or True
+        check = subprocess_run_kwargs.pop('check', None) or True
         # Run the git command
         result = self.underlying_git.runner.run_git_command(
             main_cmd_args,
@@ -525,6 +528,9 @@ class UncheckedSubcmd(GitSubcmdCommand, RootDirOp, Protocol):
             _input=_input,
             text=text,
             env=envs_vars,
+            cwd=cwd,
+            capture_output=capture_output,
+            check=check,
             **subprocess_run_kwargs
         )
         return result

--- a/src/gitbolt/git_subprocess/impl/simple.py
+++ b/src/gitbolt/git_subprocess/impl/simple.py
@@ -20,6 +20,7 @@ from gitbolt.git_subprocess import (
     LsTreeCommand,
     GitSubcmdCommand,
     AddCommand,
+    UncheckedSubcmd
 )
 from gitbolt.git_subprocess.add import AddCLIArgsBuilder
 from gitbolt.git_subprocess.constants import VERSION_CMD
@@ -131,7 +132,26 @@ class AddCommandImpl(AddCommand, GitSubcmdCommandImpl):
         return AddCommandImpl(self.root_dir, self.underlying_git)
 
 
+class UncheckedSubcmdImpl(UncheckedSubcmd, GitSubcmdCommandImpl, RootDirOp):
+    def __init__(
+        self,
+        root_dir: Path,
+        git: GitCommand
+    ):
+        super().__init__(git)
+        self._root_dir = root_dir
+
+    @override
+    @property
+    def root_dir(self) -> Path:
+        return self._root_dir
+
+    def clone(self) -> "UncheckedSubcmdImpl":
+        return UncheckedSubcmdImpl(self.root_dir, self.underlying_git)
+
+
 class SimpleGitCommand(GitCommand, RootDirOp):
+
     def __init__(
         self,
         git_root_dir: Path = Path.cwd(),
@@ -140,12 +160,14 @@ class SimpleGitCommand(GitCommand, RootDirOp):
         version_subcmd: VersionCommand | None = None,
         ls_tree_subcmd: LsTreeCommand | None = None,
         add_subcmd: AddCommand | None = None,
+        subcmd_unchecked: UncheckedSubcmd | None = None
     ):
         super().__init__(runner)
         self.git_root_dir = git_root_dir
         self._version_subcmd = version_subcmd or VersionCommandImpl(self)
         self._ls_tree = ls_tree_subcmd or LsTreeCommandImpl(self.root_dir, self)
         self._add_subcmd = add_subcmd or AddCommandImpl(self.root_dir, self)
+        self._subcmd_unchecked = subcmd_unchecked or UncheckedSubcmdImpl(self.root_dir, self)
 
     @override
     @property
@@ -171,6 +193,7 @@ class SimpleGitCommand(GitCommand, RootDirOp):
             version_subcmd=self.version_subcmd,
             ls_tree_subcmd=self.ls_tree_subcmd,
             add_subcmd=self.add_subcmd,
+            subcmd_unchecked=self.subcmd_unchecked
         )
         # endregion
         # region clone protected members
@@ -183,3 +206,7 @@ class SimpleGitCommand(GitCommand, RootDirOp):
     @property
     def root_dir(self) -> Path:
         return self.git_root_dir
+
+    @property
+    def subcmd_unchecked(self) -> UncheckedSubcmd:
+        return self._subcmd_unchecked

--- a/src/gitbolt/git_subprocess/impl/simple.py
+++ b/src/gitbolt/git_subprocess/impl/simple.py
@@ -132,7 +132,7 @@ class AddCommandImpl(AddCommand, GitSubcmdCommandImpl):
         return AddCommandImpl(self.root_dir, self.underlying_git)
 
 
-class UncheckedSubcmdImpl(UncheckedSubcmd, GitSubcmdCommandImpl, RootDirOp):
+class UncheckedSubcmdImpl(UncheckedSubcmd, GitSubcmdCommandImpl):
     def __init__(
         self,
         root_dir: Path,

--- a/src/gitbolt/git_subprocess/runner/simple_impl.py
+++ b/src/gitbolt/git_subprocess/runner/simple_impl.py
@@ -86,4 +86,4 @@ class SimpleGitCR(GitCommandRunner):
                 **subprocess_run_kwargs,
             )
         except subprocess.CalledProcessError as e:
-            raise GitCmdException(called_process_error=e, exit_code=e.returncode) from e
+            raise GitCmdException(e.stderr, called_process_error=e, exit_code=e.returncode) from e

--- a/test/test_gitbolt/test_git_subprocess/test_impl/test_simple.py
+++ b/test/test_gitbolt/test_git_subprocess/test_impl/test_simple.py
@@ -783,3 +783,6 @@ class TestAddSubcmd:
         ).stdout
         assert "a-file" in indexed_files
         assert "b-file" in indexed_files
+
+
+# TODO: write exhaustive tests for unchecked subcmd

--- a/test/test_gitbolt/test_git_subprocess/test_impl/test_simple.py
+++ b/test/test_gitbolt/test_git_subprocess/test_impl/test_simple.py
@@ -5,7 +5,6 @@
 Tests for Git command interfaces with default implementation using subprocess calls.
 """
 
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -642,11 +641,9 @@ class TestLsTreeSubcmd:
         git = SimpleGitCommand(enc_local)
         Path(enc_local, "a-file").write_text("a-file")
         git.add_subcmd.add(".")
-        subprocess.run(["git", "config", "--local", "user.name", "suhas"], cwd=enc_local, check=True)
-        subprocess.run(["git", "config", "--local", "user.email", "suhas@example.com"], cwd=enc_local, check=True)
-        subprocess.run(
-            ["git", "commit", "-m", "committed a-file"], check=True, cwd=enc_local
-        )
+        git.subcmd_unchecked.run(["config", "--local", "user.name", "suhas"])
+        git.subcmd_unchecked.run(["config", "--local", "user.email", "suhas@example.com"])
+        git.subcmd_unchecked.run(["commit", "-m", "committed a-file"])
         assert (
             git.ls_tree_subcmd.ls_tree("HEAD")
             == "100644 blob 7c35e066a9001b24677ae572214d292cebc55979	a-file"
@@ -742,10 +739,9 @@ class TestAddSubcmd:
         git.add_subcmd.add(".")
         assert (
             "a-file"
-            in subprocess.run(
-                ["git", "diff", "--cached", "--name-only"],
+            in git.subcmd_unchecked.run(
+                ["diff", "--cached", "--name-only"],
                 cwd=enc_local,
-                stdout=subprocess.PIPE,
                 text=True,
             ).stdout
         )
@@ -755,10 +751,8 @@ class TestAddSubcmd:
         Path(enc_local, "b-file").write_text("b-file")
         git = SimpleGitCommand(enc_local)
         git.add_subcmd.add("*-file")
-        indexed_files = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
-            cwd=enc_local,
-            stdout=subprocess.PIPE,
+        indexed_files = git.subcmd_unchecked.run(
+            ["diff", "--cached", "--name-only"],
             text=True,
         ).stdout
         assert "a-file" in indexed_files
@@ -769,10 +763,8 @@ class TestAddSubcmd:
         Path(enc_local, "b-file").write_text("b-file")
         git = SimpleGitCommand(enc_local)
         git.add_subcmd.add("a-file", "b-file")
-        indexed_files = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
-            cwd=enc_local,
-            stdout=subprocess.PIPE,
+        indexed_files = git.subcmd_unchecked.run(
+            ["diff", "--cached", "--name-only"],
             text=True,
         ).stdout
         assert "a-file" in indexed_files
@@ -785,10 +777,8 @@ class TestAddSubcmd:
         pathspec_file.write_text("*-file")
         git = SimpleGitCommand(enc_local)
         git.add_subcmd.add(pathspec_from_file=pathspec_file)
-        indexed_files = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
-            cwd=enc_local,
-            stdout=subprocess.PIPE,
+        indexed_files = git.subcmd_unchecked.run(
+            ["diff", "--cached", "--name-only"],
             text=True,
         ).stdout
         assert "a-file" in indexed_files


### PR DESCRIPTION
Method `git.unchecked_subcmd.run()` is intended to run commands and subcommands directly using the gitbolt's git interface inside a subprocess.

### Rationale
- Users should be able to experiment and run commands.
- A unified interface to run commands until all the subcommands have been implemented.